### PR TITLE
Error: Add Alias for Shared Pointer of `Error`.

### DIFF
--- a/error/include/error/error.hpp
+++ b/error/include/error/error.hpp
@@ -39,4 +39,16 @@ class Error : public std::exception {
  */
 using ErrorPtr = std::shared_ptr<Error>;
 
+/**
+ * @brief Creates a new error pointer with the given format for the message.
+ * @tparam T Variadic template parameter pack for format arguments.
+ * @param fmt A format string for the message.
+ * @param args Format arguments.
+ * @return Shared pointer to a new error.
+ */
+template <typename... T>
+ErrorPtr make(fmt::format_string<T...> fmt, T&&... args) {
+  return std::make_shared<Error>(fmt, std::forward<T>(args)...);
+}
+
 }  // namespace error

--- a/error/include/error/error.hpp
+++ b/error/include/error/error.hpp
@@ -3,6 +3,7 @@
 #include <fmt/core.h>
 
 #include <exception>
+#include <memory>
 #include <string>
 #include <utility>
 
@@ -32,5 +33,10 @@ class Error : public std::exception {
    */
   const char* what() const noexcept override;
 };
+
+/**
+ * @brief Alias for a shared pointer to the `Error` class.
+ */
+using ErrorPtr = std::shared_ptr<Error>;
 
 }  // namespace error

--- a/error/test/error_test.cpp
+++ b/error/test/error_test.cpp
@@ -16,12 +16,12 @@ TEST_CASE("Error Construction") {
 
 TEST_CASE("Error Pointer Construction") {
   SECTION("With one argument") {
-    const auto err = std::make_shared<error::Error>("unknown error");
+    const error::ErrorPtr err = error::make("unknown error");
     REQUIRE(std::string("unknown error") == err->what());
   }
 
   SECTION("With one or more arguments") {
-    const auto err = std::make_shared<error::Error>("HTTP error {}", 404);
+    const error::ErrorPtr err = error::make("HTTP error {}", 404);
     REQUIRE(std::string("HTTP error 404") == err->what());
   }
 }

--- a/error/test/error_test.cpp
+++ b/error/test/error_test.cpp
@@ -14,6 +14,18 @@ TEST_CASE("Error Construction") {
   }
 }
 
+TEST_CASE("Error Pointer Construction") {
+  SECTION("With one argument") {
+    const auto err = std::make_shared<error::Error>("unknown error");
+    REQUIRE(std::string("unknown error") == err->what());
+  }
+
+  SECTION("With one or more arguments") {
+    const auto err = std::make_shared<error::Error>("HTTP error {}", 404);
+    REQUIRE(std::string("HTTP error 404") == err->what());
+  }
+}
+
 TEST_CASE("Error Throwing and Catching") {
   SECTION("Catch as error::Error") {
     try {


### PR DESCRIPTION
Added the following additions:
- Introduced the `ErrorPtr` alias, representing `std::shared_ptr<Error>`.
- Implemented the `make` function to create a new `ErrorPtr`.

Closes #9.