### PR TITLE
Error: Add `Error::matches` Method

### DIFF
--- a/error/include/error/error.hpp
+++ b/error/include/error/error.hpp
@@ -32,6 +32,13 @@ class Error : public std::exception {
    * @return Pointer to a null-terminated string with explanatory information.
    */
   const char* what() const noexcept override;
+
+  /**
+   * @brief Checks if the error message matches the given string.
+   * @param str The string to be matched.
+   * @return True if it matches, false otherwise.
+   */
+  bool match(const std::string& str) const noexcept;
 };
 
 /**

--- a/error/include/error/error.hpp
+++ b/error/include/error/error.hpp
@@ -35,10 +35,10 @@ class Error : public std::exception {
 
   /**
    * @brief Checks if the error message matches the given string.
-   * @param str The string to be matched.
+   * @param str A string to be matched.
    * @return True if it matches, false otherwise.
    */
-  bool match(const std::string& str) const noexcept;
+  bool matches(const std::string& str) const noexcept;
 };
 
 /**

--- a/error/src/error.cpp
+++ b/error/src/error.cpp
@@ -4,7 +4,7 @@ namespace error {
 
 const char* Error::what() const noexcept { return message.c_str(); }
 
-bool Error::match(const std::string& str) const noexcept {
+bool Error::matches(const std::string& str) const noexcept {
   return message == str;
 }
 

--- a/error/src/error.cpp
+++ b/error/src/error.cpp
@@ -4,4 +4,8 @@ namespace error {
 
 const char* Error::what() const noexcept { return message.c_str(); }
 
+bool Error::match(const std::string& str) const noexcept {
+  return message == str;
+}
+
 }  // namespace error

--- a/error/test/error_test.cpp
+++ b/error/test/error_test.cpp
@@ -5,24 +5,24 @@
 TEST_CASE("Error Construction") {
   SECTION("With one argument") {
     const error::Error err("unknown error");
-    REQUIRE(std::string("unknown error") == err.what());
+    REQUIRE(err.match("unknown error"));
   }
 
   SECTION("With one or more arguments") {
     const error::Error err("HTTP error {}", 404);
-    REQUIRE(std::string("HTTP error 404") == err.what());
+    REQUIRE(err.match("HTTP error 404"));
   }
 }
 
 TEST_CASE("Error Pointer Construction") {
   SECTION("With one argument") {
     const error::ErrorPtr err = error::make("unknown error");
-    REQUIRE(std::string("unknown error") == err->what());
+    REQUIRE(err->match("unknown error"));
   }
 
   SECTION("With one or more arguments") {
     const error::ErrorPtr err = error::make("HTTP error {}", 404);
-    REQUIRE(std::string("HTTP error 404") == err->what());
+    REQUIRE(err->match("HTTP error 404"));
   }
 }
 
@@ -31,7 +31,7 @@ TEST_CASE("Error Throwing and Catching") {
     try {
       throw error::Error("unknown error");
     } catch (const error::Error& err) {
-      REQUIRE(std::string("unknown error") == err.what());
+      REQUIRE(err.match("unknown error"));
     } catch (...) {
       FAIL("Expected to be caught as error::Error");
     }
@@ -46,4 +46,9 @@ TEST_CASE("Error Throwing and Catching") {
       FAIL("Expected to be caught as std::exception");
     }
   }
+}
+
+TEST_CASE("Error Message Matching") {
+  const error::Error err("unknown error");
+  REQUIRE(err.match("unknown error"));
 }

--- a/error/test/error_test.cpp
+++ b/error/test/error_test.cpp
@@ -5,24 +5,24 @@
 TEST_CASE("Error Construction") {
   SECTION("With one argument") {
     const error::Error err("unknown error");
-    REQUIRE(err.match("unknown error"));
+    REQUIRE(err.matches("unknown error"));
   }
 
   SECTION("With one or more arguments") {
     const error::Error err("HTTP error {}", 404);
-    REQUIRE(err.match("HTTP error 404"));
+    REQUIRE(err.matches("HTTP error 404"));
   }
 }
 
 TEST_CASE("Error Pointer Construction") {
   SECTION("With one argument") {
     const error::ErrorPtr err = error::make("unknown error");
-    REQUIRE(err->match("unknown error"));
+    REQUIRE(err->matches("unknown error"));
   }
 
   SECTION("With one or more arguments") {
     const error::ErrorPtr err = error::make("HTTP error {}", 404);
-    REQUIRE(err->match("HTTP error 404"));
+    REQUIRE(err->matches("HTTP error 404"));
   }
 }
 
@@ -31,7 +31,7 @@ TEST_CASE("Error Throwing and Catching") {
     try {
       throw error::Error("unknown error");
     } catch (const error::Error& err) {
-      REQUIRE(err.match("unknown error"));
+      REQUIRE(err.matches("unknown error"));
     } catch (...) {
       FAIL("Expected to be caught as error::Error");
     }
@@ -50,5 +50,5 @@ TEST_CASE("Error Throwing and Catching") {
 
 TEST_CASE("Error Message Matching") {
   const error::Error err("unknown error");
-  REQUIRE(err.match("unknown error"));
+  REQUIRE(err.matches("unknown error"));
 }


### PR DESCRIPTION
Introduce the `Error::matches` method to facilitate comparison of the error with a given string. 
Closes #14.