### PR TITLE
Error: Simplify `error::Error`

### DIFF
--- a/error/include/error/error.hpp
+++ b/error/include/error/error.hpp
@@ -26,13 +26,6 @@ struct Error : public std::exception {
    * @return Pointer to a null-terminated string with explanatory information.
    */
   const char* what() const noexcept override;
-
-  /**
-   * @brief Checks if the error message matches the given string.
-   * @param str A string to be matched.
-   * @return True if it matches, false otherwise.
-   */
-  bool matches(const std::string& str) const noexcept;
 };
 
 /**

--- a/error/include/error/error.hpp
+++ b/error/include/error/error.hpp
@@ -3,7 +3,6 @@
 #include <fmt/core.h>
 
 #include <exception>
-#include <memory>
 #include <string>
 #include <utility>
 
@@ -27,11 +26,6 @@ struct Error : public std::exception {
    */
   const char* what() const noexcept override;
 };
-
-/**
- * @brief Alias for a shared pointer to the `Error` class.
- */
-using ErrorPtr = std::shared_ptr<Error>;
 
 /**
  * @brief Creates a new error object with a formatted message.

--- a/error/include/error/error.hpp
+++ b/error/include/error/error.hpp
@@ -10,13 +10,11 @@
 namespace error {
 
 /**
- * @brief A class that represents error information.
+ * @brief A struct that represents error information.
  */
-class Error : public std::exception {
- private:
+struct Error : public std::exception {
   std::string message; /**< The error message. */
 
- public:
   /**
    * @brief Constructs a new error with the given format for the message.
    * @tparam T Variadic template parameter pack for format arguments.

--- a/error/include/error/error.hpp
+++ b/error/include/error/error.hpp
@@ -10,20 +10,16 @@
 namespace error {
 
 /**
- * @brief A struct that represents error information.
+ * @brief Represents error information.
  */
 struct Error : public std::exception {
   std::string message; /**< The error message. */
 
   /**
-   * @brief Constructs a new error with the given format for the message.
-   * @tparam T Variadic template parameter pack for format arguments.
-   * @param fmt A format string for the message.
-   * @param args Format arguments.
+   * @brief Constructs a new error object with the given message.
+   * @param msg An error message.
    */
-  template <typename... T>
-  Error(fmt::format_string<T...> fmt, T&&... args)
-      : message(fmt::format(fmt, std::forward<T>(args)...)) {}
+  Error(const std::string& msg);
 
   /**
    * @brief Returns the explanatory string.
@@ -45,15 +41,15 @@ struct Error : public std::exception {
 using ErrorPtr = std::shared_ptr<Error>;
 
 /**
- * @brief Creates a new error pointer with the given format for the message.
+ * @brief Creates a new error object with a formatted message.
  * @tparam T Variadic template parameter pack for format arguments.
  * @param fmt A format string for the message.
  * @param args Format arguments.
- * @return Shared pointer to a new error.
+ * @return A new error object.
  */
 template <typename... T>
-ErrorPtr make(fmt::format_string<T...> fmt, T&&... args) {
-  return std::make_shared<Error>(fmt, std::forward<T>(args)...);
+Error format(fmt::format_string<T...> fmt, T&&... args) {
+  return Error(fmt::format(fmt, std::forward<T>(args)...));
 }
 
 }  // namespace error

--- a/error/src/error.cpp
+++ b/error/src/error.cpp
@@ -2,6 +2,8 @@
 
 namespace error {
 
+Error::Error(const std::string& msg) : message(msg) {}
+
 const char* Error::what() const noexcept { return message.c_str(); }
 
 bool Error::matches(const std::string& str) const noexcept {

--- a/error/src/error.cpp
+++ b/error/src/error.cpp
@@ -6,8 +6,4 @@ Error::Error(const std::string& msg) : message(msg) {}
 
 const char* Error::what() const noexcept { return message.c_str(); }
 
-bool Error::matches(const std::string& str) const noexcept {
-  return message == str;
-}
-
 }  // namespace error

--- a/error/test/error_test.cpp
+++ b/error/test/error_test.cpp
@@ -40,8 +40,3 @@ TEST_CASE("Error Throwing and Catching") {
     }
   }
 }
-
-TEST_CASE("Error Message Matching") {
-  const error::Error err("unknown error");
-  REQUIRE(err.matches("unknown error"));
-}

--- a/error/test/error_test.cpp
+++ b/error/test/error_test.cpp
@@ -5,24 +5,24 @@
 TEST_CASE("Error Construction") {
   SECTION("With one argument") {
     const error::Error err("unknown error");
-    REQUIRE(err.matches("unknown error"));
+    REQUIRE(err.message == "unknown error");
   }
 
   SECTION("With one or more arguments") {
     const error::Error err("HTTP error {}", 404);
-    REQUIRE(err.matches("HTTP error 404"));
+    REQUIRE(err.message == "HTTP error 404");
   }
 }
 
 TEST_CASE("Error Pointer Construction") {
   SECTION("With one argument") {
     const error::ErrorPtr err = error::make("unknown error");
-    REQUIRE(err->matches("unknown error"));
+    REQUIRE(err->message == "unknown error");
   }
 
   SECTION("With one or more arguments") {
     const error::ErrorPtr err = error::make("HTTP error {}", 404);
-    REQUIRE(err->matches("HTTP error 404"));
+    REQUIRE(err->message == "HTTP error 404");
   }
 }
 
@@ -31,7 +31,7 @@ TEST_CASE("Error Throwing and Catching") {
     try {
       throw error::Error("unknown error");
     } catch (const error::Error& err) {
-      REQUIRE(err.matches("unknown error"));
+      REQUIRE(err.message == "unknown error");
     } catch (...) {
       FAIL("Expected to be caught as error::Error");
     }

--- a/error/test/error_test.cpp
+++ b/error/test/error_test.cpp
@@ -8,15 +8,8 @@ TEST_CASE("Error Construction") {
 }
 
 TEST_CASE("Error Construction With Formatting") {
-  SECTION("With one argument") {
-    const error::Error err = error::format("unknown error");
-    REQUIRE(err.message == "unknown error");
-  }
-
-  SECTION("With one or more arguments") {
-    const error::Error err = error::format("HTTP error {}", 404);
-    REQUIRE(err.message == "HTTP error 404");
-  }
+  const error::Error err = error::format("HTTP error {}", 404);
+  REQUIRE(err.message == "HTTP error 404");
 }
 
 TEST_CASE("Error Throwing and Catching") {

--- a/error/test/error_test.cpp
+++ b/error/test/error_test.cpp
@@ -3,26 +3,19 @@
 #include <string>
 
 TEST_CASE("Error Construction") {
+  const error::Error err("unknown error");
+  REQUIRE(err.message == "unknown error");
+}
+
+TEST_CASE("Error Construction With Formatting") {
   SECTION("With one argument") {
-    const error::Error err("unknown error");
+    const error::Error err = error::format("unknown error");
     REQUIRE(err.message == "unknown error");
   }
 
   SECTION("With one or more arguments") {
-    const error::Error err("HTTP error {}", 404);
+    const error::Error err = error::format("HTTP error {}", 404);
     REQUIRE(err.message == "HTTP error 404");
-  }
-}
-
-TEST_CASE("Error Pointer Construction") {
-  SECTION("With one argument") {
-    const error::ErrorPtr err = error::make("unknown error");
-    REQUIRE(err->message == "unknown error");
-  }
-
-  SECTION("With one or more arguments") {
-    const error::ErrorPtr err = error::make("HTTP error {}", 404);
-    REQUIRE(err->message == "HTTP error 404");
   }
 }
 


### PR DESCRIPTION
This pull request simplifies the `error` namespace by making the following changes:
- Changed `Error` from a class to a struct with public member accessibility.
- Restored the `Error` constructor to accept a single message string.
- Removed the `Error::matches` method.
- Removed the `ErrorPtr` alias.
- Renamed the `make` function to `format`.