### PR TITLE
Error: Add `Error` Comparison Operators

### DIFF
--- a/error/include/error/error.hpp
+++ b/error/include/error/error.hpp
@@ -47,4 +47,12 @@ Error format(fmt::format_string<T...> fmt, T&&... args) {
  */
 bool operator==(const Error& lhs, const Error& rhs);
 
+/**
+ * @brief Checks if two error objects are not equal.
+ * @param lhs The left-hand side error object.
+ * @param rhs The right-hand side error object.
+ * @return True if not equal, false otherwise.
+ */
+bool operator!=(const Error& lhs, const Error& rhs);
+
 }  // namespace error

--- a/error/include/error/error.hpp
+++ b/error/include/error/error.hpp
@@ -39,4 +39,12 @@ Error format(fmt::format_string<T...> fmt, T&&... args) {
   return Error(fmt::format(fmt, std::forward<T>(args)...));
 }
 
+/**
+ * @brief Checks if two error objects are equal.
+ * @param lhs The left-hand side error object.
+ * @param rhs The right-hand side error object.
+ * @return True if equal, false otherwise.
+ */
+bool operator==(const Error& lhs, const Error& rhs);
+
 }  // namespace error

--- a/error/src/error.cpp
+++ b/error/src/error.cpp
@@ -6,4 +6,8 @@ Error::Error(const std::string& msg) : message(msg) {}
 
 const char* Error::what() const noexcept { return message.c_str(); }
 
+bool operator==(const Error& lhs, const Error& rhs) {
+  return lhs.message == rhs.message;
+}
+
 }  // namespace error

--- a/error/src/error.cpp
+++ b/error/src/error.cpp
@@ -10,4 +10,8 @@ bool operator==(const Error& lhs, const Error& rhs) {
   return lhs.message == rhs.message;
 }
 
+bool operator!=(const Error& lhs, const Error& rhs) {
+  return lhs.message != rhs.message;
+}
+
 }  // namespace error

--- a/error/test/error_test.cpp
+++ b/error/test/error_test.cpp
@@ -33,3 +33,11 @@ TEST_CASE("Error Throwing and Catching") {
     }
   }
 }
+
+TEST_CASE("Error Comparison") {
+  const auto err = error::Error("unknown error");
+  const auto err_copy = err;
+  CHECK(err == err_copy);
+  const auto other_err = error::Error("other error");
+  CHECK_FALSE(err == other_err);
+}

--- a/error/test/error_test.cpp
+++ b/error/test/error_test.cpp
@@ -38,6 +38,8 @@ TEST_CASE("Error Comparison") {
   const auto err = error::Error("unknown error");
   const auto err_copy = err;
   CHECK(err == err_copy);
+  CHECK_FALSE(err != err_copy);
   const auto other_err = error::Error("other error");
   CHECK_FALSE(err == other_err);
+  CHECK(err != other_err);
 }


### PR DESCRIPTION
Implement two operator functions (`==` and `!=`) to compare whether two `Error` objects are equal or not.

Closes #17.