### PR TITLE
Error: Add `std::ostream` Operator to Write `Error`

### DIFF
--- a/error/include/error/error.hpp
+++ b/error/include/error/error.hpp
@@ -3,6 +3,7 @@
 #include <fmt/core.h>
 
 #include <exception>
+#include <ostream>
 #include <string>
 #include <utility>
 
@@ -19,6 +20,26 @@ struct Error : public std::exception {
    * @param msg An error message.
    */
   Error(const std::string& msg);
+
+  /**
+   * @brief Writes the string representation of an error object to the given
+   * output stream.
+   * @param os The output stream.
+   * @param err The error object.
+   * @return The output stream.
+   *
+   * This operator allows an error object to be printed to the output stream
+   * using the << operator. The error message will be written to the output
+   * stream.
+   *
+   * @code{.cpp}
+   * const error::Error err("unknown error");
+   *
+   * // Print "error: unknown error"
+   * std::cout << err << std::endl;
+   * @endcode
+   */
+  friend std::ostream& operator<<(std::ostream& os, const error::Error& err);
 
   /**
    * @brief Returns the explanatory string.

--- a/error/src/error.cpp
+++ b/error/src/error.cpp
@@ -4,6 +4,10 @@ namespace error {
 
 Error::Error(const std::string& msg) : message(msg) {}
 
+std::ostream& operator<<(std::ostream& os, const error::Error& err) {
+  return os << "error: " << err.what();
+}
+
 const char* Error::what() const noexcept { return message.c_str(); }
 
 bool operator==(const Error& lhs, const Error& rhs) {

--- a/error/test/error_test.cpp
+++ b/error/test/error_test.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <error/error.hpp>
+#include <sstream>
 #include <string>
 
 TEST_CASE("Error Construction") {
@@ -42,4 +43,10 @@ TEST_CASE("Error Comparison") {
   const auto other_err = error::Error("other error");
   CHECK_FALSE(err == other_err);
   CHECK(err != other_err);
+}
+
+TEST_CASE("Error Printing") {
+  const error::Error err("unknown error");
+  const auto ss = std::stringstream() << err;
+  REQUIRE(ss.str() == "error: unknown error");
 }


### PR DESCRIPTION
Closes #22.