### PR TITLE
CMake Scoped Compiler Flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ jobs:
         run: |
           cmake ${{ matrix.package }} \
             -B ${{ matrix.package }}/build \
-            -D CMAKE_CXX_FLAGS=-Werror \
             -D BUILD_TESTING=ON
 
       - name: Check code formatting
@@ -58,7 +57,6 @@ jobs:
           cmake ${{ matrix.package }} `
             -B ${{ matrix.package }}/build `
             -D CMAKE_CXX_COMPILER=cl `
-            -D CMAKE_CXX_FLAGS=/WX `
             -D BUILD_TESTING=ON
 
       - name: Build project

--- a/error/CMakeLists.txt
+++ b/error/CMakeLists.txt
@@ -2,31 +2,8 @@ cmake_minimum_required(VERSION 3.0)
 
 project(error)
 
-include(cmake/CPM.cmake)
-
-# Check if this project is the main project
-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  set(SUPPORT_TESTING TRUE)
-  set(CHECK_WARNINGS TRUE)
-
-  # Import Format.cmake to format source code
-  cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
-endif()
-
-if(SUPPORT_TESTING AND BUILD_TESTING)
-  enable_testing()
-
-  # Import Catch2 as the main testing framework
-  cpmaddpackage("gh:catchorg/Catch2@3.3.2")
-  include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
-
-  # Test coverage is not supported on MSVC
-  if(NOT MSVC)
-    set(CHECK_COVERAGE TRUE)
-  endif()
-endif()
-
 # Import dependencies
+include(cmake/CPM.cmake)
 cpmaddpackage("gh:fmtlib/fmt#10.0.0")
 
 # Build the main library
@@ -34,32 +11,42 @@ add_library(error src/error.cpp)
 target_include_directories(error PUBLIC include)
 target_link_libraries(error PUBLIC fmt)
 
-if(SUPPORT_TESTING AND BUILD_TESTING)
-  # Build tests for the main library
-  add_executable(error_test test/error_test.cpp)
-  target_link_libraries(error_test PRIVATE error Catch2::Catch2WithMain)
-  catch_discover_tests(error_test)
-endif()
+# Check if this project is the main project
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  # Import Format.cmake to format source code
+  cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
 
-# Get all targets in this directory
-get_property(
-  TARGETS
-  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  PROPERTY BUILDSYSTEM_TARGETS)
+  if(BUILD_TESTING)
+    enable_testing()
 
-foreach(TARGET IN LISTS TARGETS)
-  # Statically analyze code by checking for warnings
-  if(CHECK_WARNINGS)
+    # Import Catch2 as the main testing framework
+    cpmaddpackage("gh:catchorg/Catch2@3.3.2")
+    include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
+
+    # Build tests for the main library
+    add_executable(error_test test/error_test.cpp)
+    target_link_libraries(error_test PRIVATE error Catch2::Catch2WithMain)
+    catch_discover_tests(error_test)
+  endif()
+
+  # Get all targets in this directory
+  get_property(
+    TARGETS
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    PROPERTY BUILDSYSTEM_TARGETS)
+
+  foreach(TARGET IN LISTS TARGETS)
+    # Statically analyze code by checking for warnings
     if(MSVC)
       target_compile_options(${TARGET} PRIVATE /WX /permissive- /W4 /w14640 /EHsc)
     else()
       target_compile_options(${TARGET} PRIVATE -Werror -Wall -Wextra -Wnon-virtual-dtor -Wpedantic)
     endif()
-  endif()
 
-  # Enable support to check for test coverage
-  if(CHECK_COVERAGE)
-    target_compile_options(${TARGET} PRIVATE --coverage -O0)
-    target_link_options(${TARGET} PRIVATE --coverage)
-  endif()
-endforeach()
+    # Enable support to check for test coverage
+    if(BUILD_TESTING AND NOT MSVC)
+      target_compile_options(${TARGET} PRIVATE --coverage -O0)
+      target_link_options(${TARGET} PRIVATE --coverage)
+    endif()
+  endforeach()
+endif()

--- a/error/CMakeLists.txt
+++ b/error/CMakeLists.txt
@@ -9,6 +9,12 @@ else()
 endif()
 
 include(cmake/CPM.cmake)
+
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
+  set(SUPPORT_TESTING TRUE)
+endif()
+
 cpmaddpackage("gh:fmtlib/fmt#10.0.0")
 
 add_library(error src/error.cpp)
@@ -16,23 +22,19 @@ target_include_directories(error PUBLIC include)
 target_link_libraries(error PUBLIC fmt)
 target_compile_options(error PRIVATE ${WARNING_FLAGS})
 
-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
+if(SUPPORT_TESTING AND BUILD_TESTING)
+  enable_testing()
 
-  if(BUILD_TESTING)
-    enable_testing()
+  cpmaddpackage("gh:catchorg/Catch2@3.3.2")
+  include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
 
-    cpmaddpackage("gh:catchorg/Catch2@3.3.2")
-    include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
-
-    if(NOT MSVC)
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -fPIC -O0")
-    endif()
-
-    add_executable(error_test test/error_test.cpp)
-    target_link_libraries(error_test PRIVATE error Catch2::Catch2WithMain)
-    target_compile_options(error_test PRIVATE ${WARNING_FLAGS})
-
-    catch_discover_tests(error_test)
+  if(NOT MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -fPIC -O0")
   endif()
+
+  add_executable(error_test test/error_test.cpp)
+  target_link_libraries(error_test PRIVATE error Catch2::Catch2WithMain)
+  target_compile_options(error_test PRIVATE ${WARNING_FLAGS})
+
+  catch_discover_tests(error_test)
 endif()

--- a/error/CMakeLists.txt
+++ b/error/CMakeLists.txt
@@ -8,8 +8,6 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wnon-virtual-dtor -Wpedantic")
 endif()
 
-set(CMAKE_CXX_STANDARD 11)
-
 include(cmake/CPM.cmake)
 cpmaddpackage("gh:fmtlib/fmt#10.0.0")
 

--- a/error/CMakeLists.txt
+++ b/error/CMakeLists.txt
@@ -19,7 +19,7 @@ if(SUPPORT_TESTING AND BUILD_TESTING)
 
   # Test coverage is not supported on MSVC.
   if(NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -fPIC -O0")
+    set(CHECK_COVERAGE TRUE)
   endif()
 endif()
 
@@ -49,5 +49,11 @@ foreach(TARGET IN LISTS TARGETS)
     else()
       target_compile_options(${TARGET} PRIVATE -Werror -Wall -Wextra -Wnon-virtual-dtor -Wpedantic)
     endif()
+  endif()
+
+  # Enable support to check for test coverage.
+  if(CHECK_COVERAGE)
+    target_compile_options(${TARGET} PRIVATE --coverage -O0)
+    target_link_options(${TARGET} PRIVATE --coverage)
   endif()
 endforeach()

--- a/error/CMakeLists.txt
+++ b/error/CMakeLists.txt
@@ -4,45 +4,51 @@ project(error)
 
 include(cmake/CPM.cmake)
 
+# Check if this project is the main project
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
   set(SUPPORT_TESTING TRUE)
   set(CHECK_WARNINGS TRUE)
+
+  # Import Format.cmake to format source code
+  cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
 endif()
 
 if(SUPPORT_TESTING AND BUILD_TESTING)
   enable_testing()
 
-  # Import Catch2 as the main testing framework.
+  # Import Catch2 as the main testing framework
   cpmaddpackage("gh:catchorg/Catch2@3.3.2")
   include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
 
-  # Test coverage is not supported on MSVC.
+  # Test coverage is not supported on MSVC
   if(NOT MSVC)
     set(CHECK_COVERAGE TRUE)
   endif()
 endif()
 
+# Import dependencies
 cpmaddpackage("gh:fmtlib/fmt#10.0.0")
 
+# Build the main library
 add_library(error src/error.cpp)
 target_include_directories(error PUBLIC include)
 target_link_libraries(error PUBLIC fmt)
 
 if(SUPPORT_TESTING AND BUILD_TESTING)
+  # Build tests for the main library
   add_executable(error_test test/error_test.cpp)
   target_link_libraries(error_test PRIVATE error Catch2::Catch2WithMain)
   catch_discover_tests(error_test)
 endif()
 
-# Get all targets in this directory.
+# Get all targets in this directory
 get_property(
   TARGETS
   DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   PROPERTY BUILDSYSTEM_TARGETS)
 
 foreach(TARGET IN LISTS TARGETS)
-  # Statically analyze code by checking for warnings.
+  # Statically analyze code by checking for warnings
   if(CHECK_WARNINGS)
     if(MSVC)
       target_compile_options(${TARGET} PRIVATE /WX /permissive- /W4 /w14640 /EHsc)
@@ -51,7 +57,7 @@ foreach(TARGET IN LISTS TARGETS)
     endif()
   endif()
 
-  # Enable support to check for test coverage.
+  # Enable support to check for test coverage
   if(CHECK_COVERAGE)
     target_compile_options(${TARGET} PRIVATE --coverage -O0)
     target_link_options(${TARGET} PRIVATE --coverage)

--- a/error/CMakeLists.txt
+++ b/error/CMakeLists.txt
@@ -3,9 +3,9 @@ cmake_minimum_required(VERSION 3.0)
 project(error)
 
 if(MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive- /W4 /w14640 /EHsc")
+  set(WARNING_FLAGS /permissive- /W4 /w14640 /EHsc)
 else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wnon-virtual-dtor -Wpedantic")
+  set(WARNING_FLAGS -Wall -Wextra -Wnon-virtual-dtor -Wpedantic)
 endif()
 
 include(cmake/CPM.cmake)
@@ -14,6 +14,7 @@ cpmaddpackage("gh:fmtlib/fmt#10.0.0")
 add_library(error src/error.cpp)
 target_include_directories(error PUBLIC include)
 target_link_libraries(error PUBLIC fmt)
+target_compile_options(error PRIVATE ${WARNING_FLAGS})
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
@@ -30,6 +31,8 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 
     add_executable(error_test test/error_test.cpp)
     target_link_libraries(error_test PRIVATE error Catch2::Catch2WithMain)
+    target_compile_options(error_test PRIVATE ${WARNING_FLAGS})
+
     catch_discover_tests(error_test)
   endif()
 endif()

--- a/error/CMakeLists.txt
+++ b/error/CMakeLists.txt
@@ -35,7 +35,12 @@ if(SUPPORT_TESTING AND BUILD_TESTING)
   catch_discover_tests(error_test)
 endif()
 
-set(TARGETS error error_test)
+# Get all targets in this directory.
+get_property(
+  TARGETS
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  PROPERTY BUILDSYSTEM_TARGETS)
+
 foreach(TARGET IN LISTS TARGETS)
   # Statically analyze code by checking for warnings.
   if(CHECK_WARNINGS)

--- a/error/CMakeLists.txt
+++ b/error/CMakeLists.txt
@@ -15,6 +15,19 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(SUPPORT_TESTING TRUE)
 endif()
 
+if(SUPPORT_TESTING AND BUILD_TESTING)
+  enable_testing()
+
+  # Import Catch2 as the main testing framework.
+  cpmaddpackage("gh:catchorg/Catch2@3.3.2")
+  include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
+
+  # Test coverage is not supported on MSVC.
+  if(NOT MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -fPIC -O0")
+  endif()
+endif()
+
 cpmaddpackage("gh:fmtlib/fmt#10.0.0")
 
 add_library(error src/error.cpp)
@@ -23,18 +36,8 @@ target_link_libraries(error PUBLIC fmt)
 target_compile_options(error PRIVATE ${WARNING_FLAGS})
 
 if(SUPPORT_TESTING AND BUILD_TESTING)
-  enable_testing()
-
-  cpmaddpackage("gh:catchorg/Catch2@3.3.2")
-  include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
-
-  if(NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -fPIC -O0")
-  endif()
-
   add_executable(error_test test/error_test.cpp)
   target_link_libraries(error_test PRIVATE error Catch2::Catch2WithMain)
   target_compile_options(error_test PRIVATE ${WARNING_FLAGS})
-
   catch_discover_tests(error_test)
 endif()

--- a/error/CMakeLists.txt
+++ b/error/CMakeLists.txt
@@ -2,17 +2,12 @@ cmake_minimum_required(VERSION 3.0)
 
 project(error)
 
-if(MSVC)
-  set(WARNING_FLAGS /WX /permissive- /W4 /w14640 /EHsc)
-else()
-  set(WARNING_FLAGS -Werror -Wall -Wextra -Wnon-virtual-dtor -Wpedantic)
-endif()
-
 include(cmake/CPM.cmake)
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
   set(SUPPORT_TESTING TRUE)
+  set(CHECK_WARNINGS TRUE)
 endif()
 
 if(SUPPORT_TESTING AND BUILD_TESTING)
@@ -33,11 +28,21 @@ cpmaddpackage("gh:fmtlib/fmt#10.0.0")
 add_library(error src/error.cpp)
 target_include_directories(error PUBLIC include)
 target_link_libraries(error PUBLIC fmt)
-target_compile_options(error PRIVATE ${WARNING_FLAGS})
 
 if(SUPPORT_TESTING AND BUILD_TESTING)
   add_executable(error_test test/error_test.cpp)
   target_link_libraries(error_test PRIVATE error Catch2::Catch2WithMain)
-  target_compile_options(error_test PRIVATE ${WARNING_FLAGS})
   catch_discover_tests(error_test)
 endif()
+
+set(TARGETS error error_test)
+foreach(TARGET IN LISTS TARGETS)
+  # Statically analyze code by checking for warnings.
+  if(CHECK_WARNINGS)
+    if(MSVC)
+      target_compile_options(${TARGET} PRIVATE /WX /permissive- /W4 /w14640 /EHsc)
+    else()
+      target_compile_options(${TARGET} PRIVATE -Werror -Wall -Wextra -Wnon-virtual-dtor -Wpedantic)
+    endif()
+  endif()
+endforeach()

--- a/error/CMakeLists.txt
+++ b/error/CMakeLists.txt
@@ -3,9 +3,9 @@ cmake_minimum_required(VERSION 3.0)
 project(error)
 
 if(MSVC)
-  set(WARNING_FLAGS /permissive- /W4 /w14640 /EHsc)
+  set(WARNING_FLAGS /WX /permissive- /W4 /w14640 /EHsc)
 else()
-  set(WARNING_FLAGS -Wall -Wextra -Wnon-virtual-dtor -Wpedantic)
+  set(WARNING_FLAGS -Werror -Wall -Wextra -Wnon-virtual-dtor -Wpedantic)
 endif()
 
 include(cmake/CPM.cmake)


### PR DESCRIPTION
- Removed global setting of `CMAKE_CXX_STANDARD`.
- Replaced global setting of `CMAKE_CXX_FLAGS` with `target_compile_options` to specify warning flags.
- Set warnings to be treated as errors by default.
- Modified warning flags to be enabled only if the project is not included as a dependency.
- Replaced global setting of `CMAKE_CXX_FLAGS` with `target_compile_options` and `target_link_options` to specify coverage flags.
- Enhanced `CMakeLists.txt` with descriptive comments.