### PR TITLE
CMake Always Fix Format and Add Enable Check Options

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,6 @@ jobs:
             -B ${{ matrix.package }}/build \
             -D BUILD_TESTING=ON
 
-      - name: Check code formatting
-        run: |
-          cmake --build ${{ matrix.package }}/build --target fix-format
-          git diff --exit-code HEAD
-
       - name: Build project
         run: cmake --build ${{ matrix.package }}/build
 
@@ -42,6 +37,9 @@ jobs:
             ${{ matrix.package }}/build/*
             ${{ matrix.package }}/test/*
           fail-under-line: 100
+
+      - name: Check diff
+        run: git diff --exit-code HEAD
 
   debug-msvc:
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,8 @@ jobs:
           cmake ${{ matrix.package }} \
             -B ${{ matrix.package }}/build \
             -D BUILD_TESTING=ON \
-            -D CHECK_FORMAT=ON
+            -D CHECK_FORMAT=ON \
+            -D CHECK_WARNING=ON
 
       - name: Build project
         run: cmake --build ${{ matrix.package }}/build
@@ -56,7 +57,8 @@ jobs:
           cmake ${{ matrix.package }} `
             -B ${{ matrix.package }}/build `
             -D CMAKE_CXX_COMPILER=cl `
-            -D BUILD_TESTING=ON
+            -D BUILD_TESTING=ON `
+            -D CHECK_WARNING=ON
 
       - name: Build project
         run: cmake --build ${{ matrix.package }}/build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,8 @@ jobs:
             -B ${{ matrix.package }}/build \
             -D BUILD_TESTING=ON \
             -D CHECK_FORMAT=ON \
-            -D CHECK_WARNING=ON
+            -D CHECK_WARNING=ON \
+            -D CHECK_COVERAGE=ON
 
       - name: Build project
         run: cmake --build ${{ matrix.package }}/build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3.5.3
 
+      - name: Install cmake-format
+        run: pip3 install cmake-format
+
       - name: Configure CMake
         run: |
           cmake ${{ matrix.package }} `
@@ -72,6 +75,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3.5.3
 
+      # TODO: remove this later
+      - name: Install cmake-format
+        run: pip3 install cmake-format
+
       - name: Configure and build project
         uses: threeal/cmake-action@v1.1.0
         with:
@@ -86,6 +93,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.5.3
+
+      # TODO: remove this later
+      - name: Install cmake-format
+        run: pip3 install cmake-format
 
       - name: Configure and build project
         uses: threeal/cmake-action@v1.1.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,8 @@ jobs:
         run: |
           cmake ${{ matrix.package }} \
             -B ${{ matrix.package }}/build \
-            -D BUILD_TESTING=ON
+            -D BUILD_TESTING=ON \
+            -D CHECK_FORMAT=ON
 
       - name: Build project
         run: cmake --build ${{ matrix.package }}/build
@@ -50,9 +51,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3.5.3
 
-      - name: Install cmake-format
-        run: pip3 install cmake-format
-
       - name: Configure CMake
         run: |
           cmake ${{ matrix.package }} `
@@ -75,10 +73,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3.5.3
 
-      # TODO: remove this later
-      - name: Install cmake-format
-        run: pip3 install cmake-format
-
       - name: Configure and build project
         uses: threeal/cmake-action@v1.1.0
         with:
@@ -93,10 +87,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.5.3
-
-      # TODO: remove this later
-      - name: Install cmake-format
-        run: pip3 install cmake-format
 
       - name: Configure and build project
         uses: threeal/cmake-action@v1.1.0

--- a/error/.cmake-format
+++ b/error/.cmake-format
@@ -1,3 +1,4 @@
 {
-    "line_width": 120
+    "line_width": 120,
+    "max_subgroups_hwrap": 3
 }

--- a/error/CMakeLists.txt
+++ b/error/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(error PUBLIC fmt)
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   # Import Format.cmake to format source code
   cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
+  add_dependencies(error fix-format)
 
   if(BUILD_TESTING)
     enable_testing()

--- a/error/CMakeLists.txt
+++ b/error/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(error PUBLIC fmt)
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   option(CHECK_FORMAT "Enable source code formatting check" OFF)
   option(CHECK_WARNING "Enable static analysis warning check" OFF)
+  option(CHECK_COVERAGE "Enable test coverage check" OFF)
 
   # Import Format.cmake to format source code
   if(CHECK_FORMAT)
@@ -52,7 +53,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     endif()
 
     # Enable support to check for test coverage
-    if(BUILD_TESTING AND NOT MSVC)
+    if(BUILD_TESTING AND CHECK_COVERAGE AND NOT MSVC)
       target_compile_options(${TARGET} PRIVATE --coverage -O0)
       target_link_options(${TARGET} PRIVATE --coverage)
     endif()

--- a/error/CMakeLists.txt
+++ b/error/CMakeLists.txt
@@ -37,10 +37,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   endif()
 
   # Get all targets in this directory
-  get_property(
-    TARGETS
-    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    PROPERTY BUILDSYSTEM_TARGETS)
+  get_property(TARGETS DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY BUILDSYSTEM_TARGETS)
 
   foreach(TARGET IN LISTS TARGETS)
     # Statically analyze code by checking for warnings

--- a/error/CMakeLists.txt
+++ b/error/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(error PUBLIC fmt)
 # Check if this project is the main project
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   option(CHECK_FORMAT "Enable source code formatting check" OFF)
+  option(CHECK_WARNING "Enable static analysis warning check" OFF)
 
   # Import Format.cmake to format source code
   if(CHECK_FORMAT)
@@ -42,10 +43,12 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 
   foreach(TARGET IN LISTS TARGETS)
     # Statically analyze code by checking for warnings
-    if(MSVC)
-      target_compile_options(${TARGET} PRIVATE /WX /permissive- /W4 /w14640 /EHsc)
-    else()
-      target_compile_options(${TARGET} PRIVATE -Werror -Wall -Wextra -Wnon-virtual-dtor -Wpedantic)
+    if(CHECK_WARNING)
+      if(MSVC)
+        target_compile_options(${TARGET} PRIVATE /WX /permissive- /W4 /w14640 /EHsc)
+      else()
+        target_compile_options(${TARGET} PRIVATE -Werror -Wall -Wextra -Wnon-virtual-dtor -Wpedantic)
+      endif()
     endif()
 
     # Enable support to check for test coverage

--- a/error/CMakeLists.txt
+++ b/error/CMakeLists.txt
@@ -13,9 +13,13 @@ target_link_libraries(error PUBLIC fmt)
 
 # Check if this project is the main project
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  option(CHECK_FORMAT "Enable source code formatting check" OFF)
+
   # Import Format.cmake to format source code
-  cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
-  add_dependencies(error fix-format)
+  if(CHECK_FORMAT)
+    cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
+    add_dependencies(error fix-format)
+  endif()
 
   if(BUILD_TESTING)
     enable_testing()


### PR DESCRIPTION
- Ensure that the `fix-format` target from [Format.cmake](https://github.com/TheLartians/Format.cmake) is always executed.
- Introduce new options to enable the following checks:
  - Source code formatting check.
  - Static analysis warning check.
  - Test coverage check.
  > By default, these checks are turned off.