### PR TITLE
Update Format.cmake to Support Auto Installation of cmake-format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3.5.3
 
-      - name: Install cmake-format
-        run: pip3 install cmake-format
-
       - name: Configure CMake
         run: |
           cmake ${{ matrix.package }} \

--- a/error/CMakeLists.txt
+++ b/error/CMakeLists.txt
@@ -19,7 +19,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 
   # Import Format.cmake to format source code
   if(CHECK_FORMAT)
-    cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
+    cpmaddpackage("gh:threeal/Format.cmake#auto-install-cmake-format")
     add_dependencies(error fix-format)
   endif()
 


### PR DESCRIPTION
Updated the declaration of [Format.cmake](https://github.com/TheLartians/Format.cmake) in the `CMakeLists.txt` file to use the [`auto-install-cmake-format`](https://github.com/threeal/Format.cmake/tree/auto-install-cmake-format) branch. This branch includes enhancements that enable automatic installation of [cmake-format](https://cmake-format.readthedocs.io/en/latest/).