### PR TITLE
Exclude Latest Branch from Pull Request Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,9 @@ name: build
 on:
   workflow_dispatch:
   pull_request:
+    branches: ['*', '!*@latest']
   push:
-    branches: [main]
+    branches: ['*@latest', 'main']
 jobs:
   debug:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update the pull request events to trigger the `build.yml` workflow only when the pull request targets branches other than the latest branch of each subpackage (`*@latest`).