### PR TITLE
Error: Add Support for Formatting `Error` Using {fmt}

### DIFF
--- a/error/include/error/error.hpp
+++ b/error/include/error/error.hpp
@@ -77,3 +77,10 @@ bool operator==(const Error& lhs, const Error& rhs);
 bool operator!=(const Error& lhs, const Error& rhs);
 
 }  // namespace error
+
+template <>
+struct fmt::formatter<error::Error> {
+  format_parse_context::iterator parse(format_parse_context& ctx) const;
+  format_context::iterator format(const error::Error& err,
+                                  format_context& ctx) const;
+};

--- a/error/src/error.cpp
+++ b/error/src/error.cpp
@@ -19,3 +19,17 @@ bool operator!=(const Error& lhs, const Error& rhs) {
 }
 
 }  // namespace error
+
+namespace fmt {
+
+format_parse_context::iterator formatter<error::Error>::parse(
+    format_parse_context& ctx) const {
+  return ctx.begin();
+}
+
+format_context::iterator formatter<error::Error>::format(
+    const error::Error& err, format_context& ctx) const {
+  return format_to(ctx.out(), "error: {}", err.what());
+}
+
+}  // namespace fmt

--- a/error/test/error_test.cpp
+++ b/error/test/error_test.cpp
@@ -1,3 +1,5 @@
+#include <fmt/core.h>
+
 #include <catch2/catch_test_macros.hpp>
 #include <error/error.hpp>
 #include <sstream>
@@ -47,6 +49,13 @@ TEST_CASE("Error Comparison") {
 
 TEST_CASE("Error Printing") {
   const error::Error err("unknown error");
-  const auto ss = std::stringstream() << err;
-  REQUIRE(ss.str() == "error: unknown error");
+
+  SECTION("Using ostream") {
+    const auto ss = std::stringstream() << err;
+    REQUIRE(ss.str() == "error: unknown error");
+  }
+
+  SECTION("Using fmtlib") {
+    REQUIRE(fmt::format("{}", err) == "error: unknown error");
+  }
 }


### PR DESCRIPTION
Implement `fmt::formatter<error::Error>` to enable formatting of the `error::Error` struct using the [{fmt}](https://fmt.dev/latest/index.html) library. Also, add corresponding unit tests for the implementation.

Closes #29.