### PR TITLE
Error: Remove Inheritance of `std::exception` in `Error` Struct

### DIFF
--- a/error/CMakeLists.txt
+++ b/error/CMakeLists.txt
@@ -10,6 +10,7 @@ cpmaddpackage("gh:fmtlib/fmt#10.0.0")
 add_library(error src/error.cpp)
 target_include_directories(error PUBLIC include)
 target_link_libraries(error PUBLIC fmt)
+target_compile_features(error PRIVATE cxx_std_20)
 
 # Check if this project is the main project
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)

--- a/error/include/error/error.hpp
+++ b/error/include/error/error.hpp
@@ -27,7 +27,7 @@ struct Error : public std::exception {
    * stream.
    *
    * @code{.cpp}
-   * const error::Error err("unknown error");
+   * const auto err = error::make("unknown error");
    *
    * // Print "error: unknown error"
    * std::cout << err << std::endl;

--- a/error/include/error/error.hpp
+++ b/error/include/error/error.hpp
@@ -2,7 +2,6 @@
 
 #include <fmt/core.h>
 
-#include <exception>
 #include <ostream>
 #include <string>
 #include <utility>
@@ -12,7 +11,7 @@ namespace error {
 /**
  * @brief Represents error information.
  */
-struct Error : public std::exception {
+struct Error {
   std::string message; /**< The error message. */
 
   /**
@@ -39,7 +38,7 @@ struct Error : public std::exception {
    * @brief Returns the explanatory string.
    * @return Pointer to a null-terminated string with explanatory information.
    */
-  const char* what() const noexcept override;
+  const char* what() const noexcept;
 };
 
 /**

--- a/error/include/error/error.hpp
+++ b/error/include/error/error.hpp
@@ -33,12 +33,6 @@ struct Error {
    * @endcode
    */
   friend std::ostream& operator<<(std::ostream& os, const error::Error& err);
-
-  /**
-   * @brief Returns the explanatory string.
-   * @return Pointer to a null-terminated string with explanatory information.
-   */
-  const char* what() const noexcept;
 };
 
 /**

--- a/error/include/error/error.hpp
+++ b/error/include/error/error.hpp
@@ -12,7 +12,7 @@ namespace error {
  * @brief Represents error information.
  */
 struct Error {
-  std::string message; /**< The error message. */
+  const std::string message; /**< The error message. */
 
   /**
    * @brief Writes the string representation of an error object to the given

--- a/error/include/error/error.hpp
+++ b/error/include/error/error.hpp
@@ -16,12 +16,6 @@ struct Error : public std::exception {
   std::string message; /**< The error message. */
 
   /**
-   * @brief Constructs a new error object with the given message.
-   * @param msg An error message.
-   */
-  Error(const std::string& msg);
-
-  /**
    * @brief Writes the string representation of an error object to the given
    * output stream.
    * @param os The output stream.
@@ -64,7 +58,7 @@ Error make(const std::string& msg);
  */
 template <typename... T>
 Error format(fmt::format_string<T...> fmt, T&&... args) {
-  return Error(fmt::format(fmt, std::forward<T>(args)...));
+  return error::make(fmt::format(fmt, std::forward<T>(args)...));
 }
 
 /**

--- a/error/src/error.cpp
+++ b/error/src/error.cpp
@@ -2,15 +2,17 @@
 
 namespace error {
 
-Error::Error(const std::string& msg) : message(msg) {}
-
 std::ostream& operator<<(std::ostream& os, const error::Error& err) {
   return os << "error: " << err.what();
 }
 
 const char* Error::what() const noexcept { return message.c_str(); }
 
-Error make(const std::string& msg) { return Error(msg); }
+Error make(const std::string& msg) {
+  Error err;
+  err.message = msg;
+  return err;
+}
 
 bool operator==(const Error& lhs, const Error& rhs) {
   return lhs.message == rhs.message;

--- a/error/src/error.cpp
+++ b/error/src/error.cpp
@@ -8,11 +8,7 @@ std::ostream& operator<<(std::ostream& os, const error::Error& err) {
 
 const char* Error::what() const noexcept { return message.c_str(); }
 
-Error make(const std::string& msg) {
-  Error err;
-  err.message = msg;
-  return err;
-}
+Error make(const std::string& msg) { return Error{.message = msg}; }
 
 bool operator==(const Error& lhs, const Error& rhs) {
   return lhs.message == rhs.message;

--- a/error/src/error.cpp
+++ b/error/src/error.cpp
@@ -3,10 +3,8 @@
 namespace error {
 
 std::ostream& operator<<(std::ostream& os, const error::Error& err) {
-  return os << "error: " << err.what();
+  return os << "error: " << err.message;
 }
-
-const char* Error::what() const noexcept { return message.c_str(); }
 
 Error make(const std::string& msg) { return Error{.message = msg}; }
 
@@ -29,7 +27,7 @@ format_parse_context::iterator formatter<error::Error>::parse(
 
 format_context::iterator formatter<error::Error>::format(
     const error::Error& err, format_context& ctx) const {
-  return format_to(ctx.out(), "error: {}", err.what());
+  return format_to(ctx.out(), "error: {}", err.message);
 }
 
 }  // namespace fmt

--- a/error/test/error_test.cpp
+++ b/error/test/error_test.cpp
@@ -18,7 +18,7 @@ TEST_CASE("Error Construction With Formatting") {
 TEST_CASE("Error Throwing and Catching") {
   SECTION("Catch as error::Error") {
     try {
-      throw error::Error("unknown error");
+      throw error::make("unknown error");
     } catch (const error::Error& err) {
       REQUIRE(err.message == "unknown error");
     } catch (...) {
@@ -28,7 +28,7 @@ TEST_CASE("Error Throwing and Catching") {
 
   SECTION("Catch as std::exception") {
     try {
-      throw error::Error("unknown error");
+      throw error::make("unknown error");
     } catch (const std::exception& e) {
       REQUIRE(std::string("unknown error") == e.what());
     } catch (...) {
@@ -38,17 +38,17 @@ TEST_CASE("Error Throwing and Catching") {
 }
 
 TEST_CASE("Error Comparison") {
-  const auto err = error::Error("unknown error");
+  const auto err = error::make("unknown error");
   const auto err_copy = err;
   CHECK(err == err_copy);
   CHECK_FALSE(err != err_copy);
-  const auto other_err = error::Error("other error");
+  const auto other_err = error::make("other error");
   CHECK_FALSE(err == other_err);
   CHECK(err != other_err);
 }
 
 TEST_CASE("Error Printing") {
-  const error::Error err("unknown error");
+  const auto err = error::make("unknown error");
 
   SECTION("Using ostream") {
     const auto ss = std::stringstream() << err;

--- a/error/test/error_test.cpp
+++ b/error/test/error_test.cpp
@@ -15,28 +15,6 @@ TEST_CASE("Error Construction With Formatting") {
   REQUIRE(err.message == "HTTP error 404");
 }
 
-TEST_CASE("Error Throwing and Catching") {
-  SECTION("Catch as error::Error") {
-    try {
-      throw error::make("unknown error");
-    } catch (const error::Error& err) {
-      REQUIRE(err.message == "unknown error");
-    } catch (...) {
-      FAIL("Expected to be caught as error::Error");
-    }
-  }
-
-  SECTION("Catch as std::exception") {
-    try {
-      throw error::make("unknown error");
-    } catch (const std::exception& e) {
-      REQUIRE(std::string("unknown error") == e.what());
-    } catch (...) {
-      FAIL("Expected to be caught as std::exception");
-    }
-  }
-}
-
 TEST_CASE("Error Comparison") {
   const auto err = error::make("unknown error");
   const auto err_copy = err;


### PR DESCRIPTION
- Update the compilation to use C++20 standard.
- Remove the inheritance of `std::exception` in the `Error` struct.
- Change the `Error::message` property to be constant.
- Remove the constructor of the `Error` struct.
- Closes #31.