### PR TITLE
Error: Declare Operators as Friend in `Error` Struct

### DIFF
--- a/docs/error/index.rst
+++ b/docs/error/index.rst
@@ -13,8 +13,6 @@ API Docs
 .. doxygenstruct:: error::Error
    :members:
 
-.. doxygenfunction:: error::operator==
-
 .. doxygenfunction:: error::operator!=
 
 License

--- a/docs/error/index.rst
+++ b/docs/error/index.rst
@@ -13,8 +13,6 @@ API Docs
 .. doxygenstruct:: error::Error
    :members:
 
-.. doxygenfunction:: error::operator!=
-
 License
 -------
 

--- a/error/.clang-format
+++ b/error/.clang-format
@@ -1,1 +1,2 @@
 BasedOnStyle: Google
+ColumnLimit: 0

--- a/error/include/error/error.hpp
+++ b/error/include/error/error.hpp
@@ -50,6 +50,23 @@ struct Error {
    * @endcode
    */
   friend bool operator==(const Error& lhs, const Error& rhs);
+
+  /**
+   * @brief Checks if two error objects are not equal.
+   * @param lhs The left-hand side error object.
+   * @param rhs The right-hand side error object.
+   * @return True if not equal, false otherwise.
+   *
+   * This operator allows the comparison of two error objects using the != operator.
+   *
+   * @code{.cpp}
+   * const auto err = error::make("unknown error");
+   * const auto other_err = error::make("other error");
+   *
+   * assert(err != other_err);
+   * @endcode
+   */
+  friend bool operator!=(const Error& lhs, const Error& rhs);
 };
 
 /**
@@ -70,14 +87,6 @@ template <typename... T>
 Error format(fmt::format_string<T...> fmt, T&&... args) {
   return error::make(fmt::format(fmt, std::forward<T>(args)...));
 }
-
-/**
- * @brief Checks if two error objects are not equal.
- * @param lhs The left-hand side error object.
- * @param rhs The right-hand side error object.
- * @return True if not equal, false otherwise.
- */
-bool operator!=(const Error& lhs, const Error& rhs);
 
 }  // namespace error
 

--- a/error/include/error/error.hpp
+++ b/error/include/error/error.hpp
@@ -33,6 +33,23 @@ struct Error {
    * @endcode
    */
   friend std::ostream& operator<<(std::ostream& os, const error::Error& err);
+
+  /**
+   * @brief Checks if two error objects are equal.
+   * @param lhs The left-hand side error object.
+   * @param rhs The right-hand side error object.
+   * @return True if equal, false otherwise.
+   *
+   * This operator allows the comparison of two error objects using the == operator.
+   *
+   * @code{.cpp}
+   * const auto err = error::make("unknown error");
+   * const auto other_err = err;
+   *
+   * assert(err == other_err);
+   * @endcode
+   */
+  friend bool operator==(const Error& lhs, const Error& rhs);
 };
 
 /**
@@ -53,14 +70,6 @@ template <typename... T>
 Error format(fmt::format_string<T...> fmt, T&&... args) {
   return error::make(fmt::format(fmt, std::forward<T>(args)...));
 }
-
-/**
- * @brief Checks if two error objects are equal.
- * @param lhs The left-hand side error object.
- * @param rhs The right-hand side error object.
- * @return True if equal, false otherwise.
- */
-bool operator==(const Error& lhs, const Error& rhs);
 
 /**
  * @brief Checks if two error objects are not equal.

--- a/error/src/error.cpp
+++ b/error/src/error.cpp
@@ -6,11 +6,11 @@ std::ostream& operator<<(std::ostream& os, const error::Error& err) {
   return os << "error: " << err.message;
 }
 
-Error make(const std::string& msg) { return Error{.message = msg}; }
-
 bool operator==(const Error& lhs, const Error& rhs) {
   return lhs.message == rhs.message;
 }
+
+Error make(const std::string& msg) { return Error{.message = msg}; }
 
 bool operator!=(const Error& lhs, const Error& rhs) {
   return lhs.message != rhs.message;

--- a/error/src/error.cpp
+++ b/error/src/error.cpp
@@ -10,11 +10,11 @@ bool operator==(const Error& lhs, const Error& rhs) {
   return lhs.message == rhs.message;
 }
 
-Error make(const std::string& msg) { return Error{.message = msg}; }
-
 bool operator!=(const Error& lhs, const Error& rhs) {
   return lhs.message != rhs.message;
 }
+
+Error make(const std::string& msg) { return Error{.message = msg}; }
 
 }  // namespace error
 


### PR DESCRIPTION
This pull request makes the following changes to the `Error` struct:

- Declares the equality (`==`) and inequality (`!=`) operators as friend operators within the `Error` struct.
- Enhances the documentation of the operators in the `Error` struct with detailed descriptions and examples.
- Adjusts the Clang Format configuration to allow unlimited maximum line width.

Closes #38.