### PR TITLE
Update Catch2 to v3.4.0

### DIFF
--- a/error/CMakeLists.txt
+++ b/error/CMakeLists.txt
@@ -29,7 +29,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     enable_testing()
 
     # Import Catch2 as the main testing framework
-    cpmaddpackage("gh:catchorg/Catch2@3.3.2")
+    cpmaddpackage("gh:catchorg/Catch2@3.4.0")
     include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
 
     # Build tests for the main library


### PR DESCRIPTION
This pull request updates the [Catch2](https://github.com/catchorg/Catch2) dependency to the latest version, v3.4.0.